### PR TITLE
[FEAT] / 상세조회시 데이터베이스에 저장

### DIFF
--- a/restfulProject/src/main/java/com/kh/spring/ecoshop/dao/EcoShopDao.java
+++ b/restfulProject/src/main/java/com/kh/spring/ecoshop/dao/EcoShopDao.java
@@ -1,0 +1,21 @@
+package com.kh.spring.ecoshop.dao;
+
+import com.kh.spring.ecoshop.vo.EcoShop;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class EcoShopDao {
+
+    public Long getEscIdByThemeId(SqlSessionTemplate sqlSession, String themeId) {
+        return sqlSession.selectOne("ecoShopMapper.getEscIdByThemeId", themeId);
+    }
+
+    public int checkDuplicate(SqlSessionTemplate sqlSession, String contsId) {
+        return sqlSession.selectOne("ecoShopMapper.checkDuplicate", contsId);
+    }
+
+    public int insertEcoShop(SqlSessionTemplate sqlSession, EcoShop ecoShop) {
+        return sqlSession.insert("ecoShopMapper.insertEcoShop", ecoShop);
+    }
+}

--- a/restfulProject/src/main/java/com/kh/spring/ecoshop/service/EcoShopService.java
+++ b/restfulProject/src/main/java/com/kh/spring/ecoshop/service/EcoShopService.java
@@ -1,0 +1,31 @@
+package com.kh.spring.ecoshop.service;
+
+import com.kh.spring.ecoshop.dao.EcoShopDao;
+import com.kh.spring.ecoshop.vo.EcoShop;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class EcoShopService {
+
+    @Autowired
+    private EcoShopDao ecoShopDao;
+
+    @Autowired
+    private SqlSessionTemplate sqlSession;
+
+    public Long findEscId(String themeId) {
+        return ecoShopDao.getEscIdByThemeId(sqlSession, themeId);
+    }
+
+    @Transactional
+    public int insertEcoShop(EcoShop ecoShop) {
+        int count = ecoShopDao.checkDuplicate(sqlSession, ecoShop.getContsId());
+        if (count == 0) {
+            return ecoShopDao.insertEcoShop(sqlSession, ecoShop);
+        }
+        return 0;
+    }
+}

--- a/restfulProject/src/main/java/com/kh/spring/ecoshop/vo/EcoShop.java
+++ b/restfulProject/src/main/java/com/kh/spring/ecoshop/vo/EcoShop.java
@@ -1,0 +1,26 @@
+package com.kh.spring.ecoshop.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class EcoShop {
+    private int shopId;
+    private String name;
+    private String address;
+    private String phone;
+    private Double lat;
+    private Double lng;
+    private Integer isActive;
+    private Date createdAt;
+    private Date updatedAt;
+    private Long escId;
+    private String contsId;
+}

--- a/restfulProject/src/main/java/com/kh/spring/map/controller/SeoulApiController.java
+++ b/restfulProject/src/main/java/com/kh/spring/map/controller/SeoulApiController.java
@@ -4,13 +4,9 @@ import com.kh.spring.map.service.SeoulMapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/seoul")
@@ -21,13 +17,16 @@ public class SeoulApiController {
     private final SeoulMapService seoulMapService;
 
 
-    @Operation(summary = "테마 필터링", description = "테마 / 거리 / 키워드를 지정하는 API 126.974695  37.564150")
+    @Operation(summary = "테마 필터링"
+              ,description = "테마(1657588761062 ,1693986134109, 11103395, 11101339, 100578, 1765960271640,1730359504536)  / 거리(m) / 키워드를 지정하는 API (126.974695  37.564150)")
+
+
     @GetMapping("/themes/contents")
     public String theme(
             @RequestParam List<String> themeIds,
-            @RequestParam(required = false) Double x,
-            @RequestParam(required = false) Double y,
-            @RequestParam(required = false) Integer distance,
+            @RequestParam(required = false, defaultValue = "126.974695") Double x,
+            @RequestParam(required = false, defaultValue = "37.564150") Double y,
+            @RequestParam(required = false, defaultValue = "2000") Integer distance,
             @RequestParam(required = false) String keyword
     ) {
         return seoulMapService.getFilteredMapData(themeIds, x, y, distance, keyword);
@@ -36,8 +35,8 @@ public class SeoulApiController {
     @Operation(summary = "상세정보 조회", description = "가게 상세정보 조회하는 API zerowaste_0054")
     @GetMapping("/detail")
     public String detail(
-            @RequestParam String themeId,
-            @RequestParam String contsId
+            @RequestParam(defaultValue = "11103395") String themeId,
+            @RequestParam(defaultValue = "zerowaste_0054") String contsId
     ) {
         return seoulMapService.getDetail(themeId, contsId);
     }

--- a/restfulProject/src/main/java/com/kh/spring/map/service/SeoulMapService.java
+++ b/restfulProject/src/main/java/com/kh/spring/map/service/SeoulMapService.java
@@ -1,13 +1,22 @@
 package com.kh.spring.map.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.spring.ecoshop.service.EcoShopService;
+import com.kh.spring.ecoshop.vo.EcoShop;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SeoulMapService {
+
     private final SeoulMapClient seoulMapClient;
+    private final EcoShopService ecoShopService;
+    private final ObjectMapper objectMapper;
 
     public String getFilteredMapData(List<String> themeIds, Double x, Double y, Integer distance, String keyword) {
         String combinedThemeIds = String.join(",", themeIds);
@@ -15,6 +24,40 @@ public class SeoulMapService {
     }
 
     public String getDetail(String themeId, String contsId) {
-        return seoulMapClient.fetchDetail(themeId, contsId);
+        String detailJson = seoulMapClient.fetchDetail(themeId, contsId);
+
+        try {
+            JsonNode root = objectMapper.readTree(detailJson);
+            JsonNode item = root.path("body").get(0);
+
+            if (item != null) {
+                // 1. JSON 내의 COT_THEME_ID(11103395 등) 추출
+                String themeCode = item.path("COT_THEME_ID").asText();
+
+                // 2. DB에서 실제 카테고리 PK(ESC_ID) 조회
+                Long realEscId = ecoShopService.findEscId(themeCode);
+
+                if (realEscId != null) {
+                    EcoShop ecoShop = EcoShop.builder()
+                            .name(item.path("COT_CONTS_NAME").asText())
+                            .address(item.path("COT_ADDR_FULL_OLD").asText())
+                            .phone(item.path("COT_TEL_NO").asText("정보없음"))
+                            .lat(item.path("COT_COORD_Y").asDouble())
+                            .lng(item.path("COT_COORD_X").asDouble())
+                            .contsId(item.path("COT_CONTS_ID").asText()) // "zerowaste_0050"
+                            .escId(realEscId) // 조회된 PK(3) 입력
+                            .isActive(1)
+                            .build();
+
+                    ecoShopService.insertEcoShop(ecoShop);
+                } else {
+                    log.warn("매핑된 카테고리 PK를 찾을 수 없음: {}", themeCode);
+                }
+            }
+        } catch (Exception e) {
+            log.error("자동 저장 에러: {}", e.getMessage());
+        }
+
+        return detailJson;
     }
 }

--- a/restfulProject/src/main/resources/application.properties
+++ b/restfulProject/src/main/resources/application.properties
@@ -7,7 +7,8 @@ spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 
 spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
-spring.datasource.url=jdbc:oracle:thin:@localhost:1521:xe
+#spring.datasource.url=jdbc:oracle:thin:@localhost:1521:xe
+spring.datasource.url=jdbc:oracle:thin:@//localhost:1521/XEPDB1
 spring.datasource.username=EASYEARTH
 spring.datasource.password=EASYEARTH
 

--- a/restfulProject/src/main/resources/mappers/ecoshop-mapper.xml
+++ b/restfulProject/src/main/resources/mappers/ecoshop-mapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="ecoShopMapper">
+    <select id="getEscIdByThemeId" parameterType="string" resultType="long">
+        SELECT ESC_ID
+        FROM ECO_SHOP_CATEGORY
+        WHERE CONTS_ID = #{themeId}
+    </select>
+
+    <select id="checkDuplicate" parameterType="string" resultType="int">
+        SELECT COUNT(*)
+        FROM ECO_SHOP
+        WHERE CONTS_ID = #{contsId}
+    </select>
+
+    <insert id="insertEcoShop" parameterType="com.kh.spring.ecoshop.vo.EcoShop">
+        INSERT INTO ECO_SHOP (
+        NAME, ADDRESS, PHONE, LAT, LNG, ESC_ID, CONTS_ID
+        ) VALUES (
+        #{name}, #{address}, #{phone}, #{lat}, #{lng}, #{escId}, #{contsId}
+        )
+    </insert>
+</mapper>


### PR DESCRIPTION
## 🔀 Pull Request Summary

### 📌 관련 Issue
- close #32 

---

### ✨ 작업 내용
상세조회 API 실행시 자동으로 DB에 저장

**주의사항**


<img width="513" height="47" alt="스크린샷 2026-01-29 오전 11 20 24" src="https://github.com/user-attachments/assets/732b6b7e-efe1-4234-9d21-5b165f9e7ae2" />

저는 XEPDB1로 해야해 실행이 됩니다.. (오라클 설정 실수해서..)
다른분들 pull하고 데이터베이스 관련된 기능 테스트하실 때 XEPDB1은 주석처리 하시고 그 위에 있는 xe 사용하시면 됩니다.
---

### ✅ 체크리스트
- [ ] develop 브랜치로 PR을 보냈습니다.
- [ ] 관련 Issue와 연결했습니다.
- [ ] 빌드 및 실행에 문제가 없습니다.
- [ ] 불필요한 로그 / 주석을 제거했습니다.

---

### 📎 참고 사항 (선택)
리뷰어가 알아야 할 사항이 있다면 작성해주세요.
