### PR TITLE
[FEAT]채팅 기본 로직(입출/조회)

### DIFF
--- a/restfulProject/src/main/java/com/kh/spring/chat/controller/ChatController.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/controller/ChatController.java
@@ -1,31 +1,83 @@
 package com.kh.spring.chat.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kh.spring.chat.model.dto.ChatMessageDto;
+import com.kh.spring.chat.model.dto.ChatRoomDto;
+import com.kh.spring.chat.model.service.ChatService;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/chat")
-@Tag(name = "채팅", description = "채팅 관련 API")
+@Tag(name = "Chat", description = "채팅 관련 API")
+@RequiredArgsConstructor
 @Slf4j
 public class ChatController {
 
-    @Operation(summary = "채팅 테스트", description = "채팅 테스트 API")
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatService chatService;
 
-    @GetMapping("/test")
-    public ResponseEntity<?> getChatRoomList() {
-        log.info("테스트 주소");
-
-        return ResponseEntity.ok("테스트 성공");
+    // ======================================================================
+    // 1. 실시간 채팅 (WebSocket/STOMP)
+    // ======================================================================
+    
+    /**
+     * 클라이언트가 /app/chat/message 로 메시지를 보내면 이 메소드가 실행됩니다.
+     * 처리 후 /topic/chat/room/{roomId} 로 구독자들에게 메시지를 전송합니다.
+     */
+    @MessageMapping("/message") // 실제 라우팅: /app/chat/message (WebSocketConfig prefix 영향 받음)
+    public void sendMessage(ChatMessageDto messageDto) {
+        log.info("메시지 수신: {}", messageDto);
+        
+        // 1. DB에 메시지 저장
+        ChatMessageDto savedMessage = chatService.saveMessage(messageDto);
+        
+        // 2. 구독자들에게 메시지 전송
+        // 구독 주소: /topic/chat/room/{roomId}
+        messagingTemplate.convertAndSend("/topic/chat/room/" + messageDto.getChatRoomId(), savedMessage);
     }
 
+    // ======================================================================
+    // 2. REST API (Swagger에 노출됨)
+    // ======================================================================
+
+    @Operation(summary = "채팅방 목록 조회", description = "개설된 모든 채팅방 목록을 조회합니다.")
+    @GetMapping("/rooms")
+    public ResponseEntity<List<ChatRoomDto>> getChatRoomList() {
+        return ResponseEntity.ok(chatService.selectChatRoomList());
+    }
+
+    @Operation(summary = "채팅방 생성", description = "새로운 채팅방을 생성합니다.")
+    @PostMapping("/room")
+    public ResponseEntity<ChatRoomDto> createChatRoom(@RequestBody ChatRoomDto roomDto) {
+        return ResponseEntity.ok(chatService.createChatRoom(roomDto));
+    }
+
+    @Operation(summary = "채팅방 상세/입장", description = "특정 채팅방의 정보를 조회합니다.")
+    @GetMapping("/room/{roomId}")
+    public ResponseEntity<ChatRoomDto> getChatRoom(@PathVariable Long roomId) {
+        return ResponseEntity.ok(chatService.selectChatRoom(roomId));
+    }
+    
+    @Operation(summary = "이전 채팅 내역 조회 (무한 스크롤)", description = "특정 채팅방의 이전 대화 내역을 불러옵니다. cursorId를 보내면 그 이전 메시지를 50개 가져옵니다.")
+    @GetMapping("/room/{roomId}/messages")
+    public ResponseEntity<List<ChatMessageDto>> getMessageList(
+            @PathVariable Long roomId, 
+            @org.springframework.web.bind.annotation.RequestParam(required = false) Long cursorId) {
+        return ResponseEntity.ok(chatService.selectMessageList(roomId, cursorId));
+    }
 }

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/dto/ChatMessageDto.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/dto/ChatMessageDto.java
@@ -1,0 +1,26 @@
+package com.kh.spring.chat.model.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageDto {
+    
+    private Long messageId;
+    private Long chatRoomId;
+    private Long senderId;
+    private String content;
+    private String messageType; // TEXT, IMAGE, ENTER, LEAVE
+    private LocalDateTime createdAt;
+    
+    // Frontend 편의를 위한 추가 필드
+    private String senderName;
+    private String senderProfileImage;
+}

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/dto/ChatRoomDto.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/dto/ChatRoomDto.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class ChatRoomDto {
     
     private Long chatRoomId;
+    private Long creatorId; // 방 생성자 ID
     private String title;
     private String roomType; // SINGLE, GROUP
     private String lastMessageContent;
@@ -23,4 +24,5 @@ public class ChatRoomDto {
     private int memberCount; // 참여 인원 수
     private String otherMemberName; // 1:1 채팅일 경우 상대방 이름
     private String otherMemberProfile; // 1:1 채팅일 경우 상대방 프로필
+    private int unreadCount; // 안 읽은 메시지 수
 }

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/dto/ChatRoomDto.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/dto/ChatRoomDto.java
@@ -1,0 +1,26 @@
+package com.kh.spring.chat.model.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomDto {
+    
+    private Long chatRoomId;
+    private String title;
+    private String roomType; // SINGLE, GROUP
+    private String lastMessageContent;
+    private LocalDateTime lastMessageAt;
+    
+    // Frontend 편의를 위한 추가 필드
+    private int memberCount; // 참여 인원 수
+    private String otherMemberName; // 1:1 채팅일 경우 상대방 이름
+    private String otherMemberProfile; // 1:1 채팅일 경우 상대방 프로필
+}

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/repository/ChatMessageRepository.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/repository/ChatMessageRepository.java
@@ -7,6 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.kh.spring.chat.model.vo.ChatMessageEntity;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, Long> {
-    // 특정 채팅방의 메시지를 과거순으로 가져오기 (채팅 내역 로딩용)
-    List<ChatMessageEntity> findByChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
+    // 2. 무한 스크롤(커서 기반): 특정 메시지(cursorId)보다 이전에 작성된 메시지를 가져옴
+    // 첫 로딩 시에는 cursorId가 아주 큰 값(또는 null 처리)이어야 함
+    @org.springframework.data.jpa.repository.Query("SELECT m FROM ChatMessageEntity m WHERE m.chatRoom.id = :chatRoomId AND m.id < :cursorId ORDER BY m.createdAt DESC")
+    org.springframework.data.domain.Page<ChatMessageEntity> findByChatRoomIdAndIdLessThan(@org.springframework.data.repository.query.Param("chatRoomId") Long chatRoomId, @org.springframework.data.repository.query.Param("cursorId") Long cursorId, org.springframework.data.domain.Pageable pageable);
+
+    // 첫 진입 시 (가장 최신 메시지 N개)
+    org.springframework.data.domain.Page<ChatMessageEntity> findByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId, org.springframework.data.domain.Pageable pageable);
 }

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/repository/ChatMessageRepository.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/repository/ChatMessageRepository.java
@@ -1,17 +1,34 @@
 package com.kh.spring.chat.model.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kh.spring.chat.model.vo.ChatMessageEntity;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, Long> {
+
+    // 1. 특정 방, 특정 메시지 ID 이후의 메시지 개수 카운트 (안 읽은 메시지 수)
+    long countByChatRoomIdAndIdGreaterThan(Long chatRoomId, Long lastReadMessageId);
+
     // 2. 무한 스크롤(커서 기반): 특정 메시지(cursorId)보다 이전에 작성된 메시지를 가져옴
     // 첫 로딩 시에는 cursorId가 아주 큰 값(또는 null 처리)이어야 함
-    @org.springframework.data.jpa.repository.Query("SELECT m FROM ChatMessageEntity m WHERE m.chatRoom.id = :chatRoomId AND m.id < :cursorId ORDER BY m.createdAt DESC")
-    org.springframework.data.domain.Page<ChatMessageEntity> findByChatRoomIdAndIdLessThan(@org.springframework.data.repository.query.Param("chatRoomId") Long chatRoomId, @org.springframework.data.repository.query.Param("cursorId") Long cursorId, org.springframework.data.domain.Pageable pageable);
+    @Query("""
+            SELECT m
+            FROM ChatMessageEntity m
+            WHERE m.chatRoom.id = :chatRoomId
+            AND m.id < :cursorId
+            ORDER BY m.createdAt DESC
+            """)
+    Page<ChatMessageEntity> findByChatRoomIdAndIdLessThan(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable);
 
     // 첫 진입 시 (가장 최신 메시지 N개)
-    org.springframework.data.domain.Page<ChatMessageEntity> findByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId, org.springframework.data.domain.Pageable pageable);
+    Page<ChatMessageEntity> findByChatRoomIdOrderByCreatedAtDesc(
+            @Param("chatRoomId") Long chatRoomId,
+            Pageable pageable);
 }

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/repository/ChatRoomRepository.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/repository/ChatRoomRepository.java
@@ -1,11 +1,19 @@
 package com.kh.spring.chat.model.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kh.spring.chat.model.vo.ChatRoomEntity;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
 	
 	//'내가 참여한 방 목록' 등의 쿼리 추가 예정
+
+    // 내가 참여한 방 목록 ('ChatRoomUserEntity'와 조인)
+    @Query("SELECT r FROM ChatRoomEntity r JOIN ChatRoomUserEntity u ON r.id = u.chatRoom.id WHERE u.member.id = :memberId ORDER BY r.lastMessageAt DESC")
+    List<ChatRoomEntity> findChatRoomsByMemberId(@Param("memberId") Long memberId);
 
 }

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/repository/MemberRepository.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/repository/MemberRepository.java
@@ -1,13 +1,7 @@
 package com.kh.spring.chat.model.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.kh.spring.chat.model.vo.MemberEntity;
 
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
-
-	//로그인 ID로 회원 찾기
-	Optional<MemberEntity> findByLoginId(String loginId);
 }

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/service/ChatService.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/service/ChatService.java
@@ -1,0 +1,26 @@
+package com.kh.spring.chat.model.service;
+
+import java.util.List;
+
+import com.kh.spring.chat.model.dto.ChatMessageDto;
+import com.kh.spring.chat.model.dto.ChatRoomDto;
+
+public interface ChatService {
+
+    //채팅방 목록 조회
+    List<ChatRoomDto> selectChatRoomList();
+
+    //채팅방 생성
+    ChatRoomDto createChatRoom(ChatRoomDto roomDto);
+
+    //채팅방 입장 (상세 조회 check)
+    ChatRoomDto selectChatRoom(Long roomId);
+
+    //메시지 저장
+    ChatMessageDto saveMessage(ChatMessageDto messageDto);
+
+    //채팅방 메시지 내역 조회 (무한 스크롤)
+    //roomId 채팅방 ID
+    //cursorId 마지막으로 로드된 메시지 ID (첫 조회 시 null 가능)
+    List<ChatMessageDto> selectMessageList(Long roomId, Long cursorId);
+}

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/service/ChatService.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/service/ChatService.java
@@ -7,8 +7,14 @@ import com.kh.spring.chat.model.dto.ChatRoomDto;
 
 public interface ChatService {
 
-    //채팅방 목록 조회
-    List<ChatRoomDto> selectChatRoomList();
+    //채팅방 목록 조회 (memberId가 있으면 해당 회원이 참여한 방만 조회 + 안읽은 메시지 수)
+    List<ChatRoomDto> selectChatRoomList(Long memberId);
+    
+    //채팅방 참여
+    void joinChatRoom(Long roomId, Long memberId);
+
+    //채팅방 나가기 (구독 취소 개념이 아닌 참여 목록에서 제거)
+    void leaveChatRoom(Long roomId, Long memberId);
 
     //채팅방 생성
     ChatRoomDto createChatRoom(ChatRoomDto roomDto);

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/service/ChatServiceImpl.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/service/ChatServiceImpl.java
@@ -1,0 +1,138 @@
+package com.kh.spring.chat.model.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kh.spring.chat.model.dto.ChatMessageDto;
+import com.kh.spring.chat.model.dto.ChatRoomDto;
+import com.kh.spring.chat.model.repository.ChatMessageRepository;
+import com.kh.spring.chat.model.repository.ChatRoomRepository;
+import com.kh.spring.chat.model.vo.ChatMessageEntity;
+import com.kh.spring.chat.model.vo.ChatRoomEntity;
+import com.kh.spring.chat.model.vo.MemberEntity;
+import com.kh.spring.chat.model.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatServiceImpl implements ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final MemberRepository memberRepository; 
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChatRoomDto> selectChatRoomList() {
+        return chatRoomRepository.findAll().stream()
+                .map(entity -> ChatRoomDto.builder()
+                        .chatRoomId(entity.getId())
+                        .title(entity.getTitle())
+                        .roomType(entity.getRoomType())
+                        .lastMessageContent(entity.getLastMessageContent())
+                        .lastMessageAt(entity.getLastMessageAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ChatRoomDto createChatRoom(ChatRoomDto roomDto) {
+        ChatRoomEntity entity = ChatRoomEntity.builder()
+                .title(roomDto.getTitle())
+                .roomType(roomDto.getRoomType())
+                .createdAt(LocalDateTime.now())
+                .build();
+        
+        ChatRoomEntity saved = chatRoomRepository.save(entity);
+        
+        return ChatRoomDto.builder()
+                .chatRoomId(saved.getId())
+                .title(saved.getTitle())
+                .roomType(saved.getRoomType())
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ChatRoomDto selectChatRoom(Long roomId) {
+        return chatRoomRepository.findById(roomId)
+                .map(entity -> ChatRoomDto.builder()
+                        .chatRoomId(entity.getId())
+                        .title(entity.getTitle())
+                        .roomType(entity.getRoomType())
+                        .build())
+                .orElse(null);
+    }
+
+    @Override
+    public ChatMessageDto saveMessage(ChatMessageDto messageDto) {
+        // 1. 채팅방 조회
+        ChatRoomEntity chatRoom = chatRoomRepository.findById(messageDto.getChatRoomId())
+                .orElseThrow(() -> new IllegalArgumentException("Chat Room not found"));
+
+        // 2. 발신자 조회
+        MemberEntity sender = memberRepository.findById(messageDto.getSenderId())
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+        // 3. 메시지 엔티티 생성 및 저장
+        ChatMessageEntity messageEntity = ChatMessageEntity.builder()
+                .chatRoom(chatRoom)
+                .sender(sender) 
+                .content(messageDto.getContent())
+                .messageType(messageDto.getMessageType())
+                .createdAt(LocalDateTime.now())
+                .build();
+        
+        ChatMessageEntity savedMessage = chatMessageRepository.save(messageEntity);
+        
+        // 4. 저장된 메시지를 DTO로 변환하여 반환
+        messageDto.setMessageId(savedMessage.getId());
+        messageDto.setCreatedAt(savedMessage.getCreatedAt());
+        messageDto.setSenderName(sender.getName());
+        messageDto.setSenderProfileImage(sender.getProfileImageUrl());
+        
+        return messageDto;
+    }
+
+    @Override
+    public List<ChatMessageDto> selectMessageList(Long roomId, Long cursorId) {
+        // 한 번에 불러올 메시지 개수
+        int pageSize = 50;
+        org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(0, pageSize);
+        
+        org.springframework.data.domain.Page<ChatMessageEntity> messagePage;
+
+        if (cursorId == null || cursorId == 0) {
+            // 커서가 없으면 가장 최신 메시지부터 조회
+            messagePage = chatMessageRepository.findByChatRoomIdOrderByCreatedAtDesc(roomId, pageable);
+        } else {
+            // 커서(마지막 메시지 ID)보다 작은(이전) 메시지 조회
+            messagePage = chatMessageRepository.findByChatRoomIdAndIdLessThan(roomId, cursorId, pageable);
+        }
+
+        return messagePage.getContent().stream()
+                .map(entity -> ChatMessageDto.builder()
+                        .messageId(entity.getId())
+                        .chatRoomId(entity.getChatRoom().getId())
+                        .senderId(entity.getSender().getId())
+                        .senderName(entity.getSender().getName())
+                        .senderProfileImage(entity.getSender().getProfileImageUrl())
+                        .content(entity.getContent())
+                        .messageType(entity.getMessageType())
+                        .createdAt(entity.getCreatedAt())
+                        .build())
+                // DB에서 최신순(DESC)으로 가져왔으므로, 화면에 뿌릴 때는 다시 과거순(ASC)으로 뒤집는 게 보통 편함
+                // (프론트 스타일에 따라 다르지만 보통 위에서 아래로 읽으므로)
+                // 여기서는 리스트 순서를 뒤집어서 반환
+                .sorted((a, b) -> a.getCreatedAt().compareTo(b.getCreatedAt())) 
+                .collect(Collectors.toList());
+    }
+}

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/service/ChatServiceImpl.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/service/ChatServiceImpl.java
@@ -1,9 +1,11 @@
 package com.kh.spring.chat.model.service;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,10 +13,12 @@ import com.kh.spring.chat.model.dto.ChatMessageDto;
 import com.kh.spring.chat.model.dto.ChatRoomDto;
 import com.kh.spring.chat.model.repository.ChatMessageRepository;
 import com.kh.spring.chat.model.repository.ChatRoomRepository;
+import com.kh.spring.chat.model.repository.ChatRoomUserRepository;
+import com.kh.spring.chat.model.repository.MemberRepository;
 import com.kh.spring.chat.model.vo.ChatMessageEntity;
 import com.kh.spring.chat.model.vo.ChatRoomEntity;
+import com.kh.spring.chat.model.vo.ChatRoomUserEntity;
 import com.kh.spring.chat.model.vo.MemberEntity;
-import com.kh.spring.chat.model.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,24 +31,65 @@ public class ChatServiceImpl implements ChatService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
-    private final MemberRepository memberRepository; 
+    private final MemberRepository memberRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
 
+    //MemberId를 이용한 채팅방 목록(리스트) 조회
     @Override
     @Transactional(readOnly = true)
-    public List<ChatRoomDto> selectChatRoomList() {
-        return chatRoomRepository.findAll().stream()
-                .map(entity -> ChatRoomDto.builder()
-                        .chatRoomId(entity.getId())
-                        .title(entity.getTitle())
-                        .roomType(entity.getRoomType())
-                        .lastMessageContent(entity.getLastMessageContent())
-                        .lastMessageAt(entity.getLastMessageAt())
-                        .build())
+    public List<ChatRoomDto> selectChatRoomList(Long memberId) {
+        List<ChatRoomEntity> chatRooms;
+        
+        if (memberId != null) {
+            // 내가 참여한 방 목록만 조회
+            chatRooms = chatRoomRepository.findChatRoomsByMemberId(memberId);
+        } else {
+            //에러 페이지로
+            throw new IllegalArgumentException("Member not found");
+        }
+
+        return chatRooms.stream()
+                .map(entity -> {
+                    int unreadCount = 0;
+                    if (memberId != null) {
+                        // 안 읽은 메시지 수 계산
+                        unreadCount = countUnreadMessages(entity.getId(), memberId);
+                    }
+                    
+                    return ChatRoomDto.builder()
+                            .chatRoomId(entity.getId())
+                            .title(entity.getTitle())
+                            .roomType(entity.getRoomType())
+                            .lastMessageContent(entity.getLastMessageContent())
+                            .lastMessageAt(entity.getLastMessageAt())
+                            .unreadCount(unreadCount)
+                            .build();
+                })
                 .collect(Collectors.toList());
+    }
+
+    //안 읽은 메시지 갯수
+    private int countUnreadMessages(Long chatRoomId, Long memberId) {
+        // 1. 사용자의 마지막 읽은 메시지 ID 조회
+        ChatRoomUserEntity roomUser = chatRoomUserRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId)
+                .orElse(null);
+
+        if (roomUser == null) {
+            return 0;
+        }
+
+        Long lastReadMessageId = roomUser.getLastReadMessageId();
+        if (lastReadMessageId == null) {
+            lastReadMessageId = 0L;
+        }
+
+        // 2. 그 이후의 메시지 개수 카운트
+        return (int) chatMessageRepository.countByChatRoomIdAndIdGreaterThan(chatRoomId, lastReadMessageId);
     }
 
     @Override
     public ChatRoomDto createChatRoom(ChatRoomDto roomDto) {
+        // 1. 채팅방 생성(db 저장)
         ChatRoomEntity entity = ChatRoomEntity.builder()
                 .title(roomDto.getTitle())
                 .roomType(roomDto.getRoomType())
@@ -53,11 +98,63 @@ public class ChatServiceImpl implements ChatService {
         
         ChatRoomEntity saved = chatRoomRepository.save(entity);
         
+        // 2. 개설자를 참여자(ChatRoomUser)로 추가
+        if (roomDto.getCreatorId() != null) {
+            MemberEntity creator = memberRepository.findById(roomDto.getCreatorId())
+                    .orElseThrow(() -> new IllegalArgumentException("Creator not found"));
+
+            //매핑 엔티티 생성(db 저장)
+            ChatRoomUserEntity roomUser = ChatRoomUserEntity.builder()
+                    .chatRoom(saved)
+                    .member(creator)
+                    .joinedAt(LocalDateTime.now())
+                    .build();
+            
+            chatRoomUserRepository.save(roomUser);
+        }
+        //채팅방 Dto를 반환
         return ChatRoomDto.builder()
                 .chatRoomId(saved.getId())
                 .title(saved.getTitle())
                 .roomType(saved.getRoomType())
+                .creatorId(roomDto.getCreatorId())
                 .build();
+    }
+
+    //채팅방 입작 로직
+    @Override
+    public void joinChatRoom(Long roomId, Long memberId) {
+        // 이미 참여 중인지 확인(db 조회)
+        if (chatRoomUserRepository.findByChatRoomIdAndMemberId(roomId, memberId).isPresent()) {
+            return;
+        }
+
+        //참여중이라면 채팅방과 멤버 정보를 매핑 엔티티에 저장
+        ChatRoomEntity chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("ChatRoom not found"));
+        
+        MemberEntity member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+        //채팅방 유저 엔티티에 저장용 매핑 엔티티 생성
+        ChatRoomUserEntity roomUser = ChatRoomUserEntity.builder()
+                .chatRoom(chatRoom)
+                .member(member)
+                .joinedAt(LocalDateTime.now())
+                .build();
+
+        //저장
+        chatRoomUserRepository.save(roomUser);
+    }
+
+    @Override
+    public void leaveChatRoom(Long roomId, Long memberId) {
+        //참여중이라면 채팅방과 멤버 정보를 매핑 엔티티에 저장
+        ChatRoomUserEntity roomUser = chatRoomUserRepository.findByChatRoomIdAndMemberId(roomId, memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Not participating in this room"));
+        
+        //삭제
+        chatRoomUserRepository.delete(roomUser);
     }
 
     @Override
@@ -72,6 +169,7 @@ public class ChatServiceImpl implements ChatService {
                 .orElse(null);
     }
 
+    //채팅방에 메시지 저장
     @Override
     public ChatMessageDto saveMessage(ChatMessageDto messageDto) {
         // 1. 채팅방 조회
@@ -93,7 +191,7 @@ public class ChatServiceImpl implements ChatService {
         
         ChatMessageEntity savedMessage = chatMessageRepository.save(messageEntity);
         
-        // 4. 저장된 메시지를 DTO로 변환하여 반환
+        // 4. 저장된 메시지를 DTO로 변환하여 반환(갱신된 정보만 세팅)
         messageDto.setMessageId(savedMessage.getId());
         messageDto.setCreatedAt(savedMessage.getCreatedAt());
         messageDto.setSenderName(sender.getName());
@@ -102,13 +200,14 @@ public class ChatServiceImpl implements ChatService {
         return messageDto;
     }
 
+    //채팅방 메시지 조회
     @Override
     public List<ChatMessageDto> selectMessageList(Long roomId, Long cursorId) {
         // 한 번에 불러올 메시지 개수
-        int pageSize = 50;
-        org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(0, pageSize);
+        int pageSize = 30;
+        Pageable pageable = PageRequest.of(0, pageSize);
         
-        org.springframework.data.domain.Page<ChatMessageEntity> messagePage;
+        Page<ChatMessageEntity> messagePage;
 
         if (cursorId == null || cursorId == 0) {
             // 커서가 없으면 가장 최신 메시지부터 조회
@@ -118,6 +217,7 @@ public class ChatServiceImpl implements ChatService {
             messagePage = chatMessageRepository.findByChatRoomIdAndIdLessThan(roomId, cursorId, pageable);
         }
 
+        //Dto 객체로 변환
         return messagePage.getContent().stream()
                 .map(entity -> ChatMessageDto.builder()
                         .messageId(entity.getId())
@@ -129,10 +229,8 @@ public class ChatServiceImpl implements ChatService {
                         .messageType(entity.getMessageType())
                         .createdAt(entity.getCreatedAt())
                         .build())
-                // DB에서 최신순(DESC)으로 가져왔으므로, 화면에 뿌릴 때는 다시 과거순(ASC)으로 뒤집는 게 보통 편함
-                // (프론트 스타일에 따라 다르지만 보통 위에서 아래로 읽으므로)
-                // 여기서는 리스트 순서를 뒤집어서 반환
-                .sorted((a, b) -> a.getCreatedAt().compareTo(b.getCreatedAt())) 
+                // DB에서 최신순(DESC)으로 가져왔으므로, 화면에 뿌릴 때는 다시 과거순(ASC)으로 뒤집어서 출력
+                .sorted(Comparator.comparing(ChatMessageDto::getCreatedAt)) 
                 .collect(Collectors.toList());
     }
 }

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/vo/ChatMessageEntity.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/vo/ChatMessageEntity.java
@@ -14,14 +14,21 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "CHAT_MESSAGE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ChatMessageEntity {
 	
-	protected ChatMessageEntity(){}
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/vo/ChatRoomEntity.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/vo/ChatRoomEntity.java
@@ -11,14 +11,21 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "CHAT_ROOM")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ChatRoomEntity {
 	
-	protected ChatRoomEntity() {}
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/restfulProject/src/main/java/com/kh/spring/chat/model/vo/ChatRoomUserEntity.java
+++ b/restfulProject/src/main/java/com/kh/spring/chat/model/vo/ChatRoomUserEntity.java
@@ -21,9 +21,12 @@ import lombok.Getter;
 @Table(name = "CHAT_ROOM_USER", indexes = {
         @Index(name = "IDX_ROOM_MEMBER_COMP", columnList = "CHAT_ROOM_ID, MEMBER_ID")
 })
+@lombok.Builder
+@lombok.NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@lombok.AllArgsConstructor
 public class ChatRoomUserEntity {
 	
-	protected ChatRoomUserEntity() {}
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/restfulProject/src/main/java/com/kh/spring/config/WebSocketConfig.java
+++ b/restfulProject/src/main/java/com/kh/spring/config/WebSocketConfig.java
@@ -12,20 +12,23 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker //STOMP 사용 활성화
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    //접속 주소 설정
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        //클라이언트(리액트)가 처음 연결할 주소 : ws://localhost:8080/ws-chat
         registry.addEndpoint("/ws-chat")
                 .setAllowedOrigins("*")
                 .withSockJS();
     }
     
+    //메시지 라우팅
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        //메시지 구독 요청(구독 주소)
+        //메시지 구독 요청(구독 주소) 기능과
+        //topic이나 queue로 시작하는 메시지는 구독중인 모든 사람에게 즉시 전달 기능
         registry.enableSimpleBroker("/topic","/queue");
+
         //메시지 발신 요청(발신 주소)
-        //app으로 시작하면 컨트롤러(@MessageMapping으로 라우팅)
+        //app으로 시작하면 컨트롤러로 보냄(@MessageMapping으로 라우팅)
         registry.setApplicationDestinationPrefixes("/app");
     }
     

--- a/restfulProject/src/main/java/com/kh/spring/config/WebSocketConfig.java
+++ b/restfulProject/src/main/java/com/kh/spring/config/WebSocketConfig.java
@@ -7,12 +7,13 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 //채팅을 위한 웹소켓 설정입니다.
+//일반적인 웹소켓을 사용하려면 WebConfig.java에서 수정할 것
 
 @Configuration
 @EnableWebSocketMessageBroker //STOMP 사용 활성화
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    //접속 주소 설정
+    //[연결 주소] 터널 입구를 "/ws-chat"로 설정
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-chat")
@@ -23,12 +24,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     //메시지 라우팅
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        //메시지 구독 요청(구독 주소) 기능과
-        //topic이나 queue로 시작하는 메시지는 구독중인 모든 사람에게 즉시 전달 기능
+        //[구독 주소 규칙] topic이나 queue로 시작하는 메시지는 브로커가 처리
         registry.enableSimpleBroker("/topic","/queue");
 
-        //메시지 발신 요청(발신 주소)
-        //app으로 시작하면 컨트롤러로 보냄(@MessageMapping으로 라우팅)
+        //[전송 주소 규칙] app으로 시작하면 컨트롤러로 보냄(@MessageMapping으로 라우팅)
         registry.setApplicationDestinationPrefixes("/app");
     }
     


### PR DESCRIPTION
## 🔀 Pull Request Summary

### 📌 관련 Issue
- close #74 

---

### ✨ 작업 내용
채팅에 기본적으로 필요한 dto, repository


기본적으로 채팅방을 만들고. 조회하고, 입장하고 채팅방에 메시지를 쏘는 기능 구현
+ 채팅방에 참가하거나/나가는 기능 추가

db 저장도 되도록 구현

채팅방 들어갈때 이전 채팅 50개만 뜨게하는 기능도 구현 - 스크롤 올리면 이전꺼 뜨는 것도 구현
(controller,servise)

!!특이사항!!
웹소켓을 사용하지만 기존 WebConfig.java가 stomp를 사용하지 않는 설정 파일이기에
WebSocketConfig라는 채팅요청시에만 작동하는 웹소켓 설정파일을 하나 만들어둠
/app 매핑을 사용하게되면 이쪽으로 연결 될 수 있기에 버그 발생 -> 버그 발생하고 나서 고쳐도 됨

---

### ✅ 체크리스트
- [ ] develop 브랜치로 PR을 보냈습니다.
- [ ] 관련 Issue와 연결했습니다.
- [ ] 빌드 및 실행에 문제가 없습니다.
- [ ] 불필요한 로그 / 주석을 제거했습니다.

---

### 📎 참고 사항 (선택)
리뷰어가 알아야 할 사항이 있다면 작성해주세요.
